### PR TITLE
Fix invited auth workspace handoff

### DIFF
--- a/apps/web/app/(public)/auth/sign-in/route.ts
+++ b/apps/web/app/(public)/auth/sign-in/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { decodeJwtExp, fetchWorkspaces, signInWithApi } from "@/lib/auth/api";
+import { decodeJwtExp, signInWithApi } from "@/lib/auth/api";
+import { resolvePostAuthRedirect } from "@/lib/auth/post-auth-redirect";
 import {
   AUTH_ACCESS_COOKIE_NAME,
   AUTH_REFRESH_COOKIE_NAME,
@@ -52,20 +53,13 @@ export async function POST(request: NextRequest) {
       password,
       refreshCookieName: "budgetflow_refresh_token",
     });
-
-    const workspaces = await fetchWorkspaces(auth.accessToken);
-    const selectedWorkspace =
-      workspaces.find((workspace) => workspace.id === existingWorkspaceId) ??
-      workspaces[0] ??
-      null;
-    const destination =
-      redirectTo !== "/app/dashboard"
-        ? redirectTo
-        : workspaces[0]
-          ? "/app/dashboard"
-          : "/app/onboarding";
-    const redirectUrl = new URL(destination, request.url);
-    redirectUrl.searchParams.set("toast", "signed_in");
+    const { redirectUrl, selectedWorkspace } = await resolvePostAuthRedirect({
+      accessToken: auth.accessToken,
+      redirectTo,
+      requestUrl: request.url,
+      defaultToast: "signed_in",
+      preferredWorkspaceId: existingWorkspaceId,
+    });
     const response = NextResponse.redirect(redirectUrl, POST_REDIRECT_STATUS);
 
     setAccessCookie(response, auth.accessToken);

--- a/apps/web/app/(public)/auth/sign-up/route.ts
+++ b/apps/web/app/(public)/auth/sign-up/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { decodeJwtExp, fetchWorkspaces, signUpWithApi } from "@/lib/auth/api";
+import { decodeJwtExp, signUpWithApi } from "@/lib/auth/api";
+import { resolvePostAuthRedirect } from "@/lib/auth/post-auth-redirect";
 import {
   AUTH_ACCESS_COOKIE_NAME,
   AUTH_REFRESH_COOKIE_NAME,
@@ -56,16 +57,12 @@ export async function POST(request: NextRequest) {
       timezone,
       refreshCookieName: "budgetflow_refresh_token",
     });
-
-    const workspaces = await fetchWorkspaces(auth.accessToken);
-    const destination =
-      redirectTo !== "/app/dashboard"
-        ? redirectTo
-        : workspaces[0]
-          ? "/app/dashboard"
-          : "/app/onboarding";
-    const redirectUrl = new URL(destination, request.url);
-    redirectUrl.searchParams.set("toast", "account_created");
+    const { redirectUrl, selectedWorkspace } = await resolvePostAuthRedirect({
+      accessToken: auth.accessToken,
+      redirectTo,
+      requestUrl: request.url,
+      defaultToast: "account_created",
+    });
     const response = NextResponse.redirect(redirectUrl, POST_REDIRECT_STATUS);
 
     setAccessCookie(response, auth.accessToken);
@@ -74,8 +71,8 @@ export async function POST(request: NextRequest) {
       setRefreshCookie(response, auth.refreshToken);
     }
 
-    if (workspaces[0]) {
-      response.cookies.set(CURRENT_WORKSPACE_COOKIE_NAME, workspaces[0].id, {
+    if (selectedWorkspace) {
+      response.cookies.set(CURRENT_WORKSPACE_COOKIE_NAME, selectedWorkspace.id, {
         httpOnly: true,
         sameSite: "lax",
         secure: process.env.NODE_ENV === "production",

--- a/apps/web/lib/auth/post-auth-redirect.ts
+++ b/apps/web/lib/auth/post-auth-redirect.ts
@@ -1,0 +1,133 @@
+import "server-only";
+
+import { fetchWorkspaces } from "@/lib/auth/api";
+import type { WorkspaceSummary } from "@/lib/auth/types";
+import { acceptWorkspaceInvite } from "@/lib/settings";
+
+interface PostAuthRedirectInput {
+  accessToken: string;
+  redirectTo: string;
+  requestUrl: string;
+  defaultToast: string;
+  preferredWorkspaceId?: string | null;
+}
+
+interface PostAuthRedirectResult {
+  redirectUrl: URL;
+  selectedWorkspace: WorkspaceSummary | null;
+}
+
+function parseInviteToken(redirectTo: string, requestUrl: string) {
+  try {
+    const redirectUrl = new URL(redirectTo, requestUrl);
+
+    if (redirectUrl.pathname !== "/auth/accept-invite") {
+      return null;
+    }
+
+    return redirectUrl.searchParams.get("token")?.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+function pickWorkspace(
+  workspaces: WorkspaceSummary[],
+  preferredWorkspaceId?: string | null,
+) {
+  return (
+    (preferredWorkspaceId
+      ? workspaces.find((workspace) => workspace.id === preferredWorkspaceId)
+      : null) ??
+    workspaces[0] ??
+    null
+  );
+}
+
+function buildDefaultRedirectUrl(input: {
+  redirectTo: string;
+  requestUrl: string;
+  defaultToast: string;
+  workspaces: WorkspaceSummary[];
+}) {
+  const destination =
+    input.redirectTo !== "/app/dashboard"
+      ? input.redirectTo
+      : input.workspaces[0]
+        ? "/app/dashboard"
+        : "/app/onboarding";
+  const redirectUrl = new URL(destination, input.requestUrl);
+
+  redirectUrl.searchParams.set("toast", input.defaultToast);
+
+  return redirectUrl;
+}
+
+function buildInviteResult(input: {
+  requestUrl: string;
+  workspaces: WorkspaceSummary[];
+  preferredWorkspaceId?: string | null;
+}) {
+  const selectedWorkspace = pickWorkspace(
+    input.workspaces,
+    input.preferredWorkspaceId,
+  );
+  const redirectPath = input.workspaces[0] ? "/app/dashboard" : "/app/onboarding";
+  const redirectUrl = new URL(redirectPath, input.requestUrl);
+
+  return {
+    redirectUrl,
+    selectedWorkspace,
+  };
+}
+
+export async function resolvePostAuthRedirect(
+  input: PostAuthRedirectInput,
+): Promise<PostAuthRedirectResult> {
+  const inviteToken = parseInviteToken(input.redirectTo, input.requestUrl);
+
+  if (inviteToken) {
+    try {
+      const acceptedInvite = await acceptWorkspaceInvite({
+        accessToken: input.accessToken,
+        token: inviteToken,
+      });
+      const workspaces = await fetchWorkspaces(input.accessToken);
+      const selectedWorkspace =
+        workspaces.find((workspace) => workspace.id === acceptedInvite.workspaceId) ??
+        workspaces[0] ??
+        null;
+      const redirectUrl = new URL("/app/dashboard", input.requestUrl);
+
+      redirectUrl.searchParams.set("toast", "invite_accepted");
+
+      return {
+        redirectUrl,
+        selectedWorkspace,
+      };
+    } catch {
+      const workspaces = await fetchWorkspaces(input.accessToken);
+      const result = buildInviteResult({
+        requestUrl: input.requestUrl,
+        workspaces,
+        preferredWorkspaceId: input.preferredWorkspaceId,
+      });
+
+      result.redirectUrl.searchParams.set("error", "invite_accept_failed");
+
+      return result;
+    }
+  }
+
+  const workspaces = await fetchWorkspaces(input.accessToken);
+
+  return {
+    redirectUrl: buildDefaultRedirectUrl({
+      redirectTo: input.redirectTo,
+      requestUrl: input.requestUrl,
+      defaultToast: input.defaultToast,
+      workspaces,
+    }),
+    selectedWorkspace: pickWorkspace(workspaces, input.preferredWorkspaceId),
+  };
+}

--- a/apps/web/tests/e2e/advanced-household-ops.spec.ts
+++ b/apps/web/tests/e2e/advanced-household-ops.spec.ts
@@ -233,7 +233,7 @@ test("owner can manage invite, notifications, report export, and recurring runs"
     await inviteePage.getByLabel("Password").fill(inviteePassword);
     await inviteePage.getByRole("button", { name: "Create account" }).click();
 
-    await expect(inviteePage).toHaveURL(/\/app\/dashboard/);
+    await expect(inviteePage).toHaveURL(/\/app\/dashboard\?toast=invite_accepted/);
     await expect(
       inviteePage.getByRole("main").getByRole("heading", { name: workspaceName, level: 1 }),
     ).toBeVisible();


### PR DESCRIPTION
## Summary
- accept shared-space invites during sign-in and sign-up when the auth redirect target is /auth/accept-invite
- switch the current workspace cookie to the accepted shared workspace before landing on the dashboard
- lock the invite e2e flow to the direct invite_accepted dashboard redirect

## Verification
- pnpm --filter @budgetflow/web lint
- pnpm --filter @budgetflow/web build
- pnpm test:web:e2e

Closes #64