### PR TITLE
Allow removing shared workspace members

### DIFF
--- a/apps/api/src/modules/workspaces/controllers/workspace-members.controller.spec.ts
+++ b/apps/api/src/modules/workspaces/controllers/workspace-members.controller.spec.ts
@@ -7,12 +7,14 @@ describe('WorkspaceMembersController', () => {
   let workspaceMembersService: {
     listMembers: jest.Mock;
     updateMyNickname: jest.Mock;
+    removeMember: jest.Mock;
   };
 
   beforeEach(async () => {
     workspaceMembersService = {
       listMembers: jest.fn(),
       updateMyNickname: jest.fn(),
+      removeMember: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -57,5 +59,32 @@ describe('WorkspaceMembersController', () => {
       },
     );
     expect(result.nickname).toBe('Jisu');
+  });
+
+  it('removeMember should delegate to WorkspaceMembersService', async () => {
+    workspaceMembersService.removeMember.mockResolvedValue({
+      userId: 'user-2',
+      name: 'Jisu',
+      nickname: 'Jisu',
+      role: 'MEMBER',
+      status: 'LEFT',
+    });
+
+    const result = await controller.removeMember(
+      {
+        userId: 'owner-1',
+        email: 'owner@example.com',
+        sessionId: 'session-1',
+      },
+      'workspace-1',
+      'user-2',
+    );
+
+    expect(workspaceMembersService.removeMember).toHaveBeenCalledWith(
+      'workspace-1',
+      'owner-1',
+      'user-2',
+    );
+    expect(result.status).toBe('LEFT');
   });
 });

--- a/apps/api/src/modules/workspaces/controllers/workspace-members.controller.ts
+++ b/apps/api/src/modules/workspaces/controllers/workspace-members.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   Param,
   ParseUUIDPipe,
@@ -53,6 +54,21 @@ export class WorkspaceMembersController {
       workspaceId,
       user.userId,
       input,
+    );
+  }
+
+  @Delete(':memberUserId')
+  @ApiOperation({ summary: 'Remove an active workspace member' })
+  @ApiOkResponse({ type: WorkspaceMemberResponseDto })
+  removeMember(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('workspaceId', new ParseUUIDPipe()) workspaceId: string,
+    @Param('memberUserId', new ParseUUIDPipe()) memberUserId: string,
+  ): Promise<WorkspaceMemberResponseDto> {
+    return this.workspaceMembersService.removeMember(
+      workspaceId,
+      user.userId,
+      memberUserId,
     );
   }
 }

--- a/apps/api/src/modules/workspaces/services/workspace-members.service.spec.ts
+++ b/apps/api/src/modules/workspaces/services/workspace-members.service.spec.ts
@@ -1,4 +1,7 @@
-import { BadRequestException } from '@nestjs/common';
+import {
+  BadRequestException,
+  NotFoundException,
+} from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import {
   WorkspaceMemberRole,
@@ -11,22 +14,29 @@ import { WorkspaceMembersService } from './workspace-members.service';
 describe('WorkspaceMembersService', () => {
   let service: WorkspaceMembersService;
   let prisma: {
-    workspaceMember: { findMany: jest.Mock; update: jest.Mock };
+    workspaceMember: {
+      findMany: jest.Mock;
+      findUnique: jest.Mock;
+      update: jest.Mock;
+    };
   };
   let workspacesService: {
     assertMemberAccess: jest.Mock;
+    assertOwner: jest.Mock;
   };
 
   beforeEach(async () => {
     prisma = {
       workspaceMember: {
         findMany: jest.fn(),
+        findUnique: jest.fn(),
         update: jest.fn(),
       },
     };
 
     workspacesService = {
       assertMemberAccess: jest.fn(),
+      assertOwner: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -61,6 +71,14 @@ describe('WorkspaceMembersService', () => {
 
     const result = await service.listMembers('workspace-1', 'user-1');
 
+    expect(prisma.workspaceMember.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          workspaceId: 'workspace-1',
+          status: WorkspaceMemberStatus.ACTIVE,
+        },
+      }),
+    );
     expect(result[0].nickname).toBe('Jisu');
   });
 
@@ -90,5 +108,68 @@ describe('WorkspaceMembersService', () => {
     await expect(
       service.updateMyNickname('workspace-1', 'user-1', {}),
     ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('removeMember should mark an active member as left', async () => {
+    prisma.workspaceMember.findUnique.mockResolvedValue({
+      userId: 'user-2',
+      nickname: 'Jisu',
+      role: WorkspaceMemberRole.MEMBER,
+      status: WorkspaceMemberStatus.ACTIVE,
+      user: {
+        name: 'Jisu',
+      },
+    });
+    prisma.workspaceMember.update.mockResolvedValue({
+      userId: 'user-2',
+      nickname: 'Jisu',
+      role: WorkspaceMemberRole.MEMBER,
+      status: WorkspaceMemberStatus.LEFT,
+      user: {
+        name: 'Jisu',
+      },
+    });
+
+    const result = await service.removeMember(
+      'workspace-1',
+      'owner-1',
+      'user-2',
+    );
+
+    expect(workspacesService.assertOwner).toHaveBeenCalledWith(
+      'workspace-1',
+      'owner-1',
+    );
+    expect(result.status).toBe(WorkspaceMemberStatus.LEFT);
+  });
+
+  it('removeMember should reject removing the acting owner', async () => {
+    await expect(
+      service.removeMember('workspace-1', 'owner-1', 'owner-1'),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('removeMember should reject removing another owner', async () => {
+    prisma.workspaceMember.findUnique.mockResolvedValue({
+      userId: 'owner-2',
+      nickname: null,
+      role: WorkspaceMemberRole.OWNER,
+      status: WorkspaceMemberStatus.ACTIVE,
+      user: {
+        name: 'Owner Two',
+      },
+    });
+
+    await expect(
+      service.removeMember('workspace-1', 'owner-1', 'owner-2'),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('removeMember should reject missing memberships', async () => {
+    prisma.workspaceMember.findUnique.mockResolvedValue(null);
+
+    await expect(
+      service.removeMember('workspace-1', 'owner-1', 'user-2'),
+    ).rejects.toBeInstanceOf(NotFoundException);
   });
 });

--- a/apps/api/src/modules/workspaces/services/workspace-members.service.ts
+++ b/apps/api/src/modules/workspaces/services/workspace-members.service.ts
@@ -3,6 +3,10 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
+import {
+  WorkspaceMemberRole,
+  WorkspaceMemberStatus,
+} from '@budgetflow/database';
 import { PrismaService } from '../../../core/database/prisma.service';
 import { UpdateWorkspaceMemberNicknameRequestDto } from '../dto/update-workspace-member-nickname-request.dto';
 import { WorkspaceMemberResponseDto } from '../dto/workspace-member-response.dto';
@@ -24,6 +28,7 @@ export class WorkspaceMembersService {
     const memberships = await this.prisma.workspaceMember.findMany({
       where: {
         workspaceId,
+        status: WorkspaceMemberStatus.ACTIVE,
       },
       include: {
         user: true,
@@ -78,6 +83,63 @@ export class WorkspaceMembersService {
       nickname: membership.nickname,
       role: membership.role,
       status: membership.status,
+    };
+  }
+
+  async removeMember(
+    workspaceId: string,
+    actorUserId: string,
+    memberUserId: string,
+  ): Promise<WorkspaceMemberResponseDto> {
+    await this.workspacesService.assertOwner(workspaceId, actorUserId);
+
+    if (actorUserId === memberUserId) {
+      throw new BadRequestException(
+        'Owners must transfer ownership before leaving the workspace.',
+      );
+    }
+
+    const membership = await this.prisma.workspaceMember.findUnique({
+      where: {
+        workspaceId_userId: {
+          workspaceId,
+          userId: memberUserId,
+        },
+      },
+      include: {
+        user: true,
+      },
+    });
+
+    if (!membership || membership.status !== WorkspaceMemberStatus.ACTIVE) {
+      throw new NotFoundException('Workspace member was not found.');
+    }
+
+    if (membership.role === WorkspaceMemberRole.OWNER) {
+      throw new BadRequestException('Workspace owners cannot be removed.');
+    }
+
+    const removedMember = await this.prisma.workspaceMember.update({
+      where: {
+        workspaceId_userId: {
+          workspaceId,
+          userId: memberUserId,
+        },
+      },
+      data: {
+        status: WorkspaceMemberStatus.LEFT,
+      },
+      include: {
+        user: true,
+      },
+    });
+
+    return {
+      userId: removedMember.userId,
+      name: removedMember.user.name,
+      nickname: removedMember.nickname,
+      role: removedMember.role,
+      status: removedMember.status,
     };
   }
 }

--- a/apps/web/app/(protected)/app/settings/members/remove/route.ts
+++ b/apps/web/app/(protected)/app/settings/members/remove/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server";
+import { AUTH_ACCESS_COOKIE_NAME } from "@/lib/auth/constants";
+import { removeWorkspaceMember } from "@/lib/settings";
+
+export async function POST(request: NextRequest) {
+  const accessToken = request.cookies.get(AUTH_ACCESS_COOKIE_NAME)?.value;
+
+  if (!accessToken) {
+    return NextResponse.redirect(
+      new URL("/sign-in?error=session_expired", request.url),
+    );
+  }
+
+  const formData = await request.formData();
+  const workspaceId = String(formData.get("workspaceId") ?? "").trim();
+  const memberUserId = String(formData.get("memberUserId") ?? "").trim();
+
+  if (!workspaceId || !memberUserId) {
+    return NextResponse.redirect(
+      new URL("/app/settings?error=workspace_missing", request.url),
+    );
+  }
+
+  try {
+    await removeWorkspaceMember({
+      accessToken,
+      workspaceId,
+      memberUserId,
+    });
+
+    return NextResponse.redirect(
+      new URL("/app/settings?toast=member_removed", request.url),
+    );
+  } catch {
+    return NextResponse.redirect(
+      new URL("/app/settings?error=member_remove_failed", request.url),
+    );
+  }
+}

--- a/apps/web/app/(protected)/app/settings/page.tsx
+++ b/apps/web/app/(protected)/app/settings/page.tsx
@@ -24,6 +24,7 @@ import {
   fetchWorkspaceMembers,
   getWorkspaceInviteDisplayMeta,
   type WorkspaceInviteSummary,
+  type WorkspaceMemberSummary,
 } from "@/lib/settings";
 import { ALL_WORKSPACE_TYPE_OPTIONS } from "@/lib/workspace-options";
 
@@ -583,6 +584,33 @@ export default async function SettingsPage() {
               </div>
             ) : isOwner ? (
               <div className="mt-5 space-y-5">
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between gap-3">
+                    <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-slate-500">
+                      Members
+                    </h3>
+                    <AppBadge tone="subtle">{members.length}</AppBadge>
+                  </div>
+                  {members.map((member) => (
+                    <MemberCard
+                      key={member.userId}
+                      member={member}
+                      workspaceId={session.currentWorkspace!.id}
+                      canRemove={
+                        member.userId !== session.user.id && member.role !== "OWNER"
+                      }
+                      isCurrentUser={member.userId === session.user.id}
+                    />
+                  ))}
+                </div>
+
+                <div className="border-t border-slate-900/8 pt-5">
+                  <div className="mb-4 flex items-center justify-between gap-3">
+                    <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-slate-500">
+                      Invite someone
+                    </h3>
+                    <AppBadge tone="subtle">{pendingInvites.length} pending</AppBadge>
+                  </div>
                 <form
                   action="/app/settings/invites/create"
                   method="post"
@@ -625,6 +653,7 @@ export default async function SettingsPage() {
                     </AppButton>
                   </div>
                 </form>
+                </div>
 
                 {pendingInvites.length > 0 ? (
                   <div className="space-y-3">
@@ -644,8 +673,28 @@ export default async function SettingsPage() {
                 )}
               </div>
             ) : (
-              <div className="mt-5 rounded-2xl border border-dashed border-slate-300 bg-slate-50 px-4 py-4 text-sm text-slate-500">
-                Owner only.
+              <div className="mt-5 space-y-4">
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between gap-3">
+                    <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-slate-500">
+                      Members
+                    </h3>
+                    <AppBadge tone="subtle">{members.length}</AppBadge>
+                  </div>
+                  {members.map((member) => (
+                    <MemberCard
+                      key={member.userId}
+                      member={member}
+                      workspaceId={session.currentWorkspace!.id}
+                      canRemove={false}
+                      isCurrentUser={member.userId === session.user.id}
+                    />
+                  ))}
+                </div>
+
+                <div className="rounded-2xl border border-dashed border-slate-300 bg-slate-50 px-4 py-4 text-sm text-slate-500">
+                  Owner only for invite and member removal.
+                </div>
               </div>
             )
           ) : (
@@ -822,6 +871,49 @@ export default async function SettingsPage() {
         </Reveal>
       </div>
     </div>
+  );
+}
+
+function MemberCard({
+  member,
+  workspaceId,
+  canRemove,
+  isCurrentUser,
+}: {
+  member: WorkspaceMemberSummary;
+  workspaceId: string;
+  canRemove: boolean;
+  isCurrentUser: boolean;
+}) {
+  const displayName = member.nickname?.trim() || member.name;
+
+  return (
+    <article className="rounded-[1.35rem] border border-slate-900/8 bg-slate-50 px-4 py-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="text-sm font-semibold text-slate-950">{displayName}</p>
+            <AppBadge tone={member.role === "OWNER" ? "success" : "subtle"}>
+              {member.role}
+            </AppBadge>
+            {isCurrentUser ? <AppBadge tone="subtle">You</AppBadge> : null}
+          </div>
+          {member.nickname?.trim() ? (
+            <p className="mt-1 text-xs text-slate-500">{member.name}</p>
+          ) : null}
+        </div>
+
+        {canRemove ? (
+          <form action="/app/settings/members/remove" method="post">
+            <input type="hidden" name="workspaceId" value={workspaceId} />
+            <input type="hidden" name="memberUserId" value={member.userId} />
+            <AppButton type="submit" tone="danger" size="sm">
+              Remove
+            </AppButton>
+          </form>
+        ) : null}
+      </div>
+    </article>
   );
 }
 

--- a/apps/web/components/feedback/url-toast-bridge.tsx
+++ b/apps/web/components/feedback/url-toast-bridge.tsx
@@ -49,6 +49,10 @@ const TOAST_MESSAGES: Record<string, { type: "success" | "error"; text: string }
     type: "success",
     text: "Workspace profile saved.",
   },
+  member_removed: {
+    type: "success",
+    text: "Member removed from shared space.",
+  },
   settings_save_failed: {
     type: "error",
     text: "Failed to save settings.",
@@ -56,6 +60,10 @@ const TOAST_MESSAGES: Record<string, { type: "success" | "error"; text: string }
   member_save_failed: {
     type: "error",
     text: "Failed to save workspace profile.",
+  },
+  member_remove_failed: {
+    type: "error",
+    text: "Failed to remove member.",
   },
   password_changed: {
     type: "success",

--- a/apps/web/lib/settings.ts
+++ b/apps/web/lib/settings.ts
@@ -234,6 +234,31 @@ export async function updateCurrentWorkspaceMember(input: {
   return response.json();
 }
 
+export async function removeWorkspaceMember(input: {
+  accessToken: string;
+  workspaceId: string;
+  memberUserId: string;
+}) {
+  const response = await fetch(
+    `${getApiBaseUrl()}/workspaces/${input.workspaceId}/members/${input.memberUserId}`,
+    {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${input.accessToken}`,
+      },
+      cache: "no-store",
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(
+      await readErrorMessage(response, "Failed to remove workspace member."),
+    );
+  }
+
+  return response.json();
+}
+
 export async function updateWorkspaceSettings(input: WorkspaceSettingsInput) {
   const response = await fetch(
     `${getApiBaseUrl()}/workspaces/${input.workspaceId}`,

--- a/apps/web/tests/e2e/advanced-household-ops.spec.ts
+++ b/apps/web/tests/e2e/advanced-household-ops.spec.ts
@@ -240,4 +240,14 @@ test("owner can manage invite, notifications, report export, and recurring runs"
   } finally {
     await inviteeContext.close();
   }
+
+  await page.goto("/app/settings");
+  await expect(page.getByText("Playwright Invitee").first()).toBeVisible();
+  await page
+    .locator('form[action="/app/settings/members/remove"]')
+    .filter({ has: page.locator('input[name="memberUserId"]') })
+    .first()
+    .evaluate((form: HTMLFormElement) => form.requestSubmit());
+  await expect(page).toHaveURL(/\/app\/settings\?toast=member_removed/);
+  await expect(page.getByText("Playwright Invitee")).toHaveCount(0);
 });


### PR DESCRIPTION
## Summary
- add an owner-only workspace member removal API that marks removed members as LEFT
- show active shared-space members in settings and let owners remove non-owner members inline
- cover the flow with workspace member API tests and web e2e

## Verification
- pnpm --filter @budgetflow/api test -- workspace-members.service.spec.ts workspace-members.controller.spec.ts --runInBand
- pnpm --filter @budgetflow/web lint
- pnpm --filter @budgetflow/web build
- pnpm test:web:e2e

Closes #66