### PR TITLE
feat(auth): add invite email delivery and Google sign-in

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -4,6 +4,7 @@ API_PREFIX=api/v1
 
 # Public web origin used by the API for CORS.
 CORS_ORIGINS=https://app.example.com
+APP_WEB_URL=https://app.example.com
 
 # Recommended: use a managed production Postgres instead of a local container.
 DATABASE_URL=postgresql://user:password@db-host:5432/budgetflow?schema=public
@@ -21,6 +22,11 @@ AUTH_EXPOSE_REFRESH_TOKEN_IN_RESPONSE=false
 
 TRUST_PROXY=true
 PASSWORD_HASH_SALT_ROUNDS=10
+
+RESEND_API_KEY=
+INVITE_EMAIL_FROM=BudgetFlow <invites@example.com>
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
 
 RECURRING_EXECUTION_SCHEDULER_ENABLED=false
 RECURRING_EXECUTION_CRON=5,20,35,50 * * * *

--- a/apps/api/src/core/config/app-config.service.ts
+++ b/apps/api/src/core/config/app-config.service.ts
@@ -37,6 +37,10 @@ export class AppConfigService {
     return this.configService.get<string>('SWAGGER_PATH') ?? 'docs';
   }
 
+  get appWebUrl(): string | undefined {
+    return this.configService.get<string>('APP_WEB_URL') || undefined;
+  }
+
   get databaseUrl(): string {
     return this.configService.get<string>('DATABASE_URL') ?? '';
   }
@@ -156,5 +160,21 @@ export class AppConfigService {
         'RECURRING_FAILURE_NOTIFICATION_THROTTLE_MINUTES',
       ) ?? 60,
     );
+  }
+
+  get resendApiKey(): string | undefined {
+    return this.configService.get<string>('RESEND_API_KEY') || undefined;
+  }
+
+  get inviteEmailFrom(): string | undefined {
+    return this.configService.get<string>('INVITE_EMAIL_FROM') || undefined;
+  }
+
+  get googleClientId(): string | undefined {
+    return this.configService.get<string>('GOOGLE_CLIENT_ID') || undefined;
+  }
+
+  get googleClientSecret(): string | undefined {
+    return this.configService.get<string>('GOOGLE_CLIENT_SECRET') || undefined;
   }
 }

--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -24,6 +24,7 @@ import { AuthResponseDto } from './dto/auth-response.dto';
 import { AuthSessionResponseDto } from './dto/auth-session-response.dto';
 import { ChangePasswordRequestDto } from './dto/change-password-request.dto';
 import { ChangePasswordResponseDto } from './dto/change-password-response.dto';
+import { GoogleAuthRequestDto } from './dto/google-auth-request.dto';
 import { RefreshTokenRequestDto } from './dto/refresh-token-request.dto';
 import { RevokeAuthSessionResponseDto } from './dto/revoke-auth-session-response.dto';
 import { SignInRequestDto } from './dto/sign-in-request.dto';
@@ -77,6 +78,30 @@ export class AuthController {
     @Res({ passthrough: true }) response: Response,
   ): Promise<AuthResponseDto> {
     const authResponse = await this.authService.signIn(
+      input,
+      getAuthRequestContext(request),
+    );
+
+    if (authResponse.tokens.refreshToken) {
+      this.authCookieService.setRefreshTokenCookie(
+        response,
+        authResponse.tokens.refreshToken,
+      );
+    }
+
+    return this.authCookieService.toClientResponse(authResponse);
+  }
+
+  @Post('google')
+  @ApiOperation({ summary: 'Sign in with Google authorization code' })
+  @ApiBody({ type: GoogleAuthRequestDto })
+  @ApiOkResponse({ type: AuthResponseDto })
+  async signInWithGoogle(
+    @Body() input: GoogleAuthRequestDto,
+    @Req() request: Request,
+    @Res({ passthrough: true }) response: Response,
+  ): Promise<AuthResponseDto> {
+    const authResponse = await this.authService.signInWithGoogle(
       input,
       getAuthRequestContext(request),
     );

--- a/apps/api/src/modules/auth/auth.module.ts
+++ b/apps/api/src/modules/auth/auth.module.ts
@@ -13,6 +13,7 @@ import { AuthCookieService } from './services/auth-cookie.service';
 import { AuthSessionsService } from './services/auth-sessions.service';
 import { AuthService } from './services/auth.service';
 import { PasswordService } from './services/password.service';
+import { GoogleOAuthService } from './services/google-oauth.service';
 import { TokenService } from './services/token.service';
 
 @Module({
@@ -37,6 +38,7 @@ import { TokenService } from './services/token.service';
     AuthSessionsService,
     PasswordService,
     TokenService,
+    GoogleOAuthService,
     JwtAuthGuard,
     RefreshTokenGuard,
     AccessTokenStrategy,

--- a/apps/api/src/modules/auth/dto/google-auth-request.dto.ts
+++ b/apps/api/src/modules/auth/dto/google-auth-request.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsUrl, MinLength } from 'class-validator';
+
+export class GoogleAuthRequestDto {
+  @ApiProperty()
+  @IsString()
+  @MinLength(1)
+  code!: string;
+
+  @ApiProperty()
+  @IsUrl({
+    require_tld: false,
+    require_protocol: true,
+  })
+  redirectUri!: string;
+}

--- a/apps/api/src/modules/auth/services/auth.service.spec.ts
+++ b/apps/api/src/modules/auth/services/auth.service.spec.ts
@@ -5,6 +5,7 @@ import { UsersService } from '../../users/users.service';
 import { WorkspacesService } from '../../workspaces/services/workspaces.service';
 import { AuthService } from './auth.service';
 import { AuthSessionsService } from './auth-sessions.service';
+import { GoogleOAuthService } from './google-oauth.service';
 import { PasswordService } from './password.service';
 import { TokenService } from './token.service';
 
@@ -13,7 +14,9 @@ describe('AuthService', () => {
   let usersService: {
     create: jest.Mock;
     findByEmail: jest.Mock;
+    findByAuthIdentity: jest.Mock;
     findById: jest.Mock;
+    linkAuthIdentity: jest.Mock;
     toResponse: jest.Mock;
   };
   let authSessionsService: {
@@ -35,12 +38,17 @@ describe('AuthService', () => {
   let workspacesService: {
     createPersonalWorkspace: jest.Mock;
   };
+  let googleOAuthService: {
+    exchangeCodeForProfile: jest.Mock;
+  };
 
   beforeEach(async () => {
     usersService = {
       create: jest.fn(),
       findByEmail: jest.fn(),
+      findByAuthIdentity: jest.fn(),
       findById: jest.fn(),
+      linkAuthIdentity: jest.fn(),
       toResponse: jest.fn(),
     };
 
@@ -67,6 +75,10 @@ describe('AuthService', () => {
 
     workspacesService = {
       createPersonalWorkspace: jest.fn(),
+    };
+
+    googleOAuthService = {
+      exchangeCodeForProfile: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -97,6 +109,10 @@ describe('AuthService', () => {
           useValue: {
             log: jest.fn(),
           },
+        },
+        {
+          provide: GoogleOAuthService,
+          useValue: googleOAuthService,
         },
       ],
     }).compile();
@@ -251,5 +267,63 @@ describe('AuthService', () => {
       'session-1',
       'user-1',
     );
+  });
+
+  it('signInWithGoogle should create a linked social user when one does not exist', async () => {
+    const createdUser = {
+      id: 'user-2',
+      email: 'google@example.com',
+      name: 'Google User',
+      profileImageUrl: 'https://example.com/avatar.png',
+      locale: 'ko-KR',
+      timezone: 'Asia/Seoul',
+      createdAt: new Date('2026-04-02T00:00:00.000Z'),
+    };
+
+    googleOAuthService.exchangeCodeForProfile.mockResolvedValue({
+      email: 'google@example.com',
+      emailVerified: true,
+      name: 'Google User',
+      picture: 'https://example.com/avatar.png',
+      subject: 'google-subject-1',
+    });
+    usersService.findByAuthIdentity.mockResolvedValue(null);
+    usersService.findByEmail.mockResolvedValue(null);
+    usersService.create.mockResolvedValue(createdUser);
+    usersService.findById.mockResolvedValue(createdUser);
+    usersService.toResponse.mockReturnValue(createdUser);
+    tokenService.createAuthTokens.mockResolvedValue({
+      accessToken: 'google-access-token',
+      refreshToken: 'google-refresh-token',
+    });
+    passwordService.hashRefreshToken.mockResolvedValue(
+      'google-refresh-token-hash',
+    );
+
+    const result = await authService.signInWithGoogle(
+      {
+        code: 'google-code',
+        redirectUri: 'http://localhost:3001/auth/google/callback',
+      },
+      {
+        ipAddress: '127.0.0.1',
+        userAgent: 'jest',
+      },
+    );
+
+    expect(googleOAuthService.exchangeCodeForProfile).toHaveBeenCalled();
+    expect(usersService.linkAuthIdentity).toHaveBeenCalledWith({
+      userId: 'user-2',
+      provider: 'GOOGLE',
+      providerSubject: 'google-subject-1',
+      email: 'google@example.com',
+    });
+    expect(workspacesService.createPersonalWorkspace).toHaveBeenCalledWith({
+      ownerUserId: 'user-2',
+      ownerName: 'Google User',
+      locale: 'ko-KR',
+      timezone: 'Asia/Seoul',
+    });
+    expect(result.tokens.accessToken).toBe('google-access-token');
   });
 });

--- a/apps/api/src/modules/auth/services/auth.service.ts
+++ b/apps/api/src/modules/auth/services/auth.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { randomUUID } from 'node:crypto';
+import { AuthIdentityProvider } from '@budgetflow/database';
 import type { AuthenticatedUser } from '../../../common/interfaces/authenticated-request.interface';
 import { AppLoggerService } from '../../../core/logger/app-logger.service';
 import { UsersService } from '../../users/users.service';
@@ -17,6 +18,7 @@ import { SignInRequestDto } from '../dto/sign-in-request.dto';
 import { SignOutResponseDto } from '../dto/sign-out-response.dto';
 import { SignUpRequestDto } from '../dto/sign-up-request.dto';
 import { AuthSessionsService } from './auth-sessions.service';
+import { GoogleOAuthService } from './google-oauth.service';
 import { PasswordService } from './password.service';
 import { TokenService } from './token.service';
 
@@ -28,6 +30,7 @@ export class AuthService {
     private readonly authSessionsService: AuthSessionsService,
     private readonly passwordService: PasswordService,
     private readonly tokenService: TokenService,
+    private readonly googleOAuthService: GoogleOAuthService,
     private readonly logger: AppLoggerService,
   ) {}
 
@@ -82,6 +85,61 @@ export class AuthService {
     }
 
     this.logger.log('User signed in', AuthService.name, {
+      userId: user.id,
+      email: user.email,
+    });
+
+    return this.createAuthResponse(user.id, requestContext);
+  }
+
+  async signInWithGoogle(
+    input: {
+      code: string;
+      redirectUri: string;
+    },
+    requestContext: AuthRequestContext,
+  ): Promise<AuthResponseDto> {
+    const profile = await this.googleOAuthService.exchangeCodeForProfile(input);
+    const existingIdentityUser = await this.usersService.findByAuthIdentity(
+      AuthIdentityProvider.GOOGLE,
+      profile.subject,
+    );
+    let user = existingIdentityUser;
+
+    if (!user) {
+      user = await this.usersService.findByEmail(profile.email);
+
+      if (user) {
+        await this.usersService.linkAuthIdentity({
+          userId: user.id,
+          provider: AuthIdentityProvider.GOOGLE,
+          providerSubject: profile.subject,
+          email: profile.email,
+        });
+      } else {
+        user = await this.usersService.create({
+          email: profile.email,
+          passwordHash: null,
+          name: profile.name,
+          profileImageUrl: profile.picture,
+        });
+
+        await this.usersService.linkAuthIdentity({
+          userId: user.id,
+          provider: AuthIdentityProvider.GOOGLE,
+          providerSubject: profile.subject,
+          email: profile.email,
+        });
+        await this.workspacesService.createPersonalWorkspace({
+          ownerUserId: user.id,
+          ownerName: user.name,
+          locale: user.locale,
+          timezone: user.timezone,
+        });
+      }
+    }
+
+    this.logger.log('User signed in with Google', AuthService.name, {
       userId: user.id,
       email: user.email,
     });

--- a/apps/api/src/modules/auth/services/google-oauth.service.ts
+++ b/apps/api/src/modules/auth/services/google-oauth.service.ts
@@ -1,0 +1,97 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { AppConfigService } from '../../../core/config/app-config.service';
+
+export interface GoogleOAuthProfile {
+  email: string;
+  emailVerified: boolean;
+  name: string;
+  picture: string | null;
+  subject: string;
+}
+
+interface GoogleTokenResponse {
+  access_token?: string;
+  error?: string;
+  error_description?: string;
+}
+
+interface GoogleUserInfoResponse {
+  sub?: string;
+  email?: string;
+  email_verified?: boolean;
+  name?: string;
+  picture?: string;
+}
+
+@Injectable()
+export class GoogleOAuthService {
+  constructor(private readonly appConfig: AppConfigService) {}
+
+  async exchangeCodeForProfile(input: {
+    code: string;
+    redirectUri: string;
+  }): Promise<GoogleOAuthProfile> {
+    const clientId = this.appConfig.googleClientId;
+    const clientSecret = this.appConfig.googleClientSecret;
+
+    if (!clientId || !clientSecret) {
+      throw new UnauthorizedException('Google sign-in is not configured.');
+    }
+
+    const tokenResponse = await fetch('https://oauth2.googleapis.com/token', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams({
+        client_id: clientId,
+        client_secret: clientSecret,
+        code: input.code,
+        grant_type: 'authorization_code',
+        redirect_uri: input.redirectUri,
+      }),
+    });
+
+    const tokenPayload =
+      (await tokenResponse.json()) as GoogleTokenResponse;
+
+    if (!tokenResponse.ok || !tokenPayload.access_token) {
+      throw new UnauthorizedException(
+        tokenPayload.error_description ?? 'Google sign-in failed.',
+      );
+    }
+
+    const userInfoResponse = await fetch(
+      'https://openidconnect.googleapis.com/v1/userinfo',
+      {
+        headers: {
+          Authorization: `Bearer ${tokenPayload.access_token}`,
+        },
+      },
+    );
+    const userInfoPayload =
+      (await userInfoResponse.json()) as GoogleUserInfoResponse;
+
+    if (
+      !userInfoResponse.ok ||
+      !userInfoPayload.sub ||
+      !userInfoPayload.email ||
+      !userInfoPayload.email_verified
+    ) {
+      throw new UnauthorizedException(
+        'Google account email could not be verified.',
+      );
+    }
+
+    return {
+      email: userInfoPayload.email,
+      emailVerified: userInfoPayload.email_verified,
+      name:
+        userInfoPayload.name?.trim() ||
+        userInfoPayload.email.split('@')[0] ||
+        'BudgetFlow User',
+      picture: userInfoPayload.picture ?? null,
+      subject: userInfoPayload.sub,
+    };
+  }
+}

--- a/apps/api/src/modules/users/users.service.ts
+++ b/apps/api/src/modules/users/users.service.ts
@@ -3,7 +3,11 @@ import {
   ConflictException,
   Injectable,
 } from '@nestjs/common';
-import { User } from '@budgetflow/database';
+import {
+  AuthIdentityProvider,
+  Prisma,
+  User,
+} from '@budgetflow/database';
 import { PrismaService } from '../../core/database/prisma.service';
 import { UserResponseDto } from './dto/user-response.dto';
 import { UpdateUserProfileRequestDto } from './dto/update-user-profile-request.dto';
@@ -24,12 +28,32 @@ export class UsersService {
     });
   }
 
+  async findByAuthIdentity(
+    provider: AuthIdentityProvider,
+    providerSubject: string,
+  ): Promise<User | null> {
+    const identity = await this.prisma.authIdentity.findUnique({
+      where: {
+        provider_providerSubject: {
+          provider,
+          providerSubject,
+        },
+      },
+      include: {
+        user: true,
+      },
+    });
+
+    return identity?.user ?? null;
+  }
+
   async create(input: {
     email: string;
-    passwordHash: string;
+    passwordHash?: string | null;
     name: string;
     locale?: string;
     timezone?: string;
+    profileImageUrl?: string | null;
   }): Promise<User> {
     const existingUser = await this.findByEmail(input.email);
 
@@ -40,12 +64,52 @@ export class UsersService {
     return this.prisma.user.create({
       data: {
         email: input.email,
-        passwordHash: input.passwordHash,
+        passwordHash: input.passwordHash ?? null,
         name: input.name,
+        ...(input.profileImageUrl !== undefined
+          ? { profileImageUrl: input.profileImageUrl }
+          : {}),
         ...(input.locale ? { locale: input.locale } : {}),
         ...(input.timezone ? { timezone: input.timezone } : {}),
       },
     });
+  }
+
+  async linkAuthIdentity(input: {
+    userId: string;
+    provider: AuthIdentityProvider;
+    providerSubject: string;
+    email?: string | null;
+  }): Promise<void> {
+    try {
+      await this.prisma.authIdentity.upsert({
+        where: {
+          provider_providerSubject: {
+            provider: input.provider,
+            providerSubject: input.providerSubject,
+          },
+        },
+        update: {
+          userId: input.userId,
+          email: input.email ?? null,
+        },
+        create: {
+          userId: input.userId,
+          provider: input.provider,
+          providerSubject: input.providerSubject,
+          email: input.email ?? null,
+        },
+      });
+    } catch (error) {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2002'
+      ) {
+        throw new ConflictException('Authentication identity is already linked.');
+      }
+
+      throw error;
+    }
   }
 
   async updateProfile(

--- a/apps/api/src/modules/workspaces/services/workspace-invite-email.service.ts
+++ b/apps/api/src/modules/workspaces/services/workspace-invite-email.service.ts
@@ -1,0 +1,105 @@
+import { Injectable } from '@nestjs/common';
+import { AppConfigService } from '../../../core/config/app-config.service';
+import { AppLoggerService } from '../../../core/logger/app-logger.service';
+
+@Injectable()
+export class WorkspaceInviteEmailService {
+  constructor(
+    private readonly appConfig: AppConfigService,
+    private readonly logger: AppLoggerService,
+  ) {}
+
+  async sendInviteEmail(input: {
+    recipientEmail: string;
+    workspaceName: string;
+    inviteToken: string;
+    inviterName?: string | null;
+  }): Promise<void> {
+    if (
+      !this.appConfig.resendApiKey ||
+      !this.appConfig.inviteEmailFrom ||
+      !this.appConfig.appWebUrl
+    ) {
+      this.logger.warn(
+        'Skipped workspace invite email send because email delivery is not configured',
+        WorkspaceInviteEmailService.name,
+        {
+          hasAppWebUrl: Boolean(this.appConfig.appWebUrl),
+          hasInviteEmailFrom: Boolean(this.appConfig.inviteEmailFrom),
+          hasResendApiKey: Boolean(this.appConfig.resendApiKey),
+          recipientEmail: input.recipientEmail,
+          workspaceName: input.workspaceName,
+        },
+      );
+
+      return;
+    }
+
+    const inviteUrl = new URL(
+      `/join/${input.inviteToken}`,
+      this.appConfig.appWebUrl,
+    ).toString();
+    const inviterLabel = input.inviterName?.trim() || 'A BudgetFlow owner';
+    const subject = `${inviterLabel} invited you to ${input.workspaceName}`;
+    const text = [
+      `${inviterLabel} invited you to join "${input.workspaceName}" on BudgetFlow.`,
+      '',
+      `Open this invite: ${inviteUrl}`,
+      '',
+      'If you already have an account, sign in with the invited email address before accepting the invite.',
+    ].join('\n');
+    const html = `
+      <div style="font-family:Arial,sans-serif;line-height:1.6;color:#0f172a">
+        <p style="font-size:12px;letter-spacing:0.18em;text-transform:uppercase;color:#059669;font-weight:700;margin:0 0 16px">BudgetFlow Shared Space</p>
+        <h1 style="font-size:24px;line-height:1.2;margin:0 0 16px">Join ${this.escapeHtml(input.workspaceName)}</h1>
+        <p style="margin:0 0 16px">${this.escapeHtml(inviterLabel)} invited you to collaborate in a shared budget workspace on BudgetFlow.</p>
+        <p style="margin:24px 0">
+          <a href="${inviteUrl}" style="display:inline-block;padding:12px 20px;border-radius:999px;background:#10b981;color:#042f2e;text-decoration:none;font-weight:700">
+            Open invite
+          </a>
+        </p>
+        <p style="margin:0 0 8px;font-size:14px;color:#475569">If the button does not work, use this link:</p>
+        <p style="margin:0;font-size:14px;word-break:break-all"><a href="${inviteUrl}" style="color:#0f766e">${inviteUrl}</a></p>
+      </div>
+    `;
+
+    const response = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.appConfig.resendApiKey}`,
+        'Content-Type': 'application/json',
+        'User-Agent': 'budgetflow-api/0.1.0',
+      },
+      body: JSON.stringify({
+        from: this.appConfig.inviteEmailFrom,
+        to: [input.recipientEmail],
+        subject,
+        html,
+        text,
+      }),
+    });
+
+    if (!response.ok) {
+      const responseText = await response.text().catch(() => '');
+
+      this.logger.warn(
+        'Workspace invite email send failed',
+        WorkspaceInviteEmailService.name,
+        {
+          recipientEmail: input.recipientEmail,
+          responseText,
+          status: response.status,
+        },
+      );
+    }
+  }
+
+  private escapeHtml(value: string) {
+    return value
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;')
+      .replaceAll('"', '&quot;')
+      .replaceAll("'", '&#39;');
+  }
+}

--- a/apps/api/src/modules/workspaces/services/workspace-invites.service.spec.ts
+++ b/apps/api/src/modules/workspaces/services/workspace-invites.service.spec.ts
@@ -9,6 +9,8 @@ import {
   WorkspaceMemberStatus,
 } from '@budgetflow/database';
 import { PrismaService } from '../../../core/database/prisma.service';
+import { AppLoggerService } from '../../../core/logger/app-logger.service';
+import { WorkspaceInviteEmailService } from './workspace-invite-email.service';
 import { WorkspacesService } from './workspaces.service';
 import { WorkspaceInvitesService } from './workspace-invites.service';
 
@@ -16,6 +18,7 @@ describe('WorkspaceInvitesService', () => {
   let service: WorkspaceInvitesService;
   let prisma: {
     user: { findUnique: jest.Mock };
+    workspace: { findUnique: jest.Mock };
     workspaceMember: { findUnique: jest.Mock };
     workspaceInvite: {
       create: jest.Mock;
@@ -29,10 +32,14 @@ describe('WorkspaceInvitesService', () => {
   let workspacesService: {
     assertOwner: jest.Mock;
   };
+  let workspaceInviteEmailService: {
+    sendInviteEmail: jest.Mock;
+  };
 
   beforeEach(async () => {
     prisma = {
       user: { findUnique: jest.fn() },
+      workspace: { findUnique: jest.fn() },
       workspaceMember: { findUnique: jest.fn() },
       workspaceInvite: {
         create: jest.fn(),
@@ -48,6 +55,10 @@ describe('WorkspaceInvitesService', () => {
       assertOwner: jest.fn(),
     };
 
+    workspaceInviteEmailService = {
+      sendInviteEmail: jest.fn(),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         WorkspaceInvitesService,
@@ -58,6 +69,16 @@ describe('WorkspaceInvitesService', () => {
         {
           provide: WorkspacesService,
           useValue: workspacesService,
+        },
+        {
+          provide: WorkspaceInviteEmailService,
+          useValue: workspaceInviteEmailService,
+        },
+        {
+          provide: AppLoggerService,
+          useValue: {
+            warn: jest.fn(),
+          },
         },
       ],
     }).compile();
@@ -77,6 +98,12 @@ describe('WorkspaceInvitesService', () => {
       token: 'token-1',
       expiresAt: new Date('2026-04-01T00:00:00.000Z'),
     });
+    prisma.workspace.findUnique.mockResolvedValue({
+      name: 'Shared Home',
+    });
+    prisma.user.findUnique
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ name: 'Minji' });
 
     const result = await service.createInvite('workspace-1', 'owner-1', {
       email: 'jisu@example.com',
@@ -88,6 +115,12 @@ describe('WorkspaceInvitesService', () => {
       'owner-1',
     );
     expect(prisma.workspaceMember.findUnique).not.toHaveBeenCalled();
+    expect(workspaceInviteEmailService.sendInviteEmail).toHaveBeenCalledWith({
+      recipientEmail: 'jisu@example.com',
+      workspaceName: 'Shared Home',
+      inviteToken: 'token-1',
+      inviterName: 'Minji',
+    });
     expect(result.email).toBe('jisu@example.com');
   });
 
@@ -235,6 +268,12 @@ describe('WorkspaceInvitesService', () => {
       token: 'token-2',
       expiresAt: new Date('2026-04-08T00:00:00.000Z'),
     });
+    prisma.workspace.findUnique.mockResolvedValue({
+      name: 'Shared Home',
+    });
+    prisma.user.findUnique.mockResolvedValue({
+      name: 'Minji',
+    });
 
     const result = await service.resendInvite(
       'workspace-1',
@@ -244,5 +283,11 @@ describe('WorkspaceInvitesService', () => {
 
     expect(result.token).toBe('token-2');
     expect(result.status).toBe(WorkspaceMemberStatus.INVITED);
+    expect(workspaceInviteEmailService.sendInviteEmail).toHaveBeenCalledWith({
+      recipientEmail: 'jisu@example.com',
+      workspaceName: 'Shared Home',
+      inviteToken: 'token-2',
+      inviterName: 'Minji',
+    });
   });
 });

--- a/apps/api/src/modules/workspaces/services/workspace-invites.service.ts
+++ b/apps/api/src/modules/workspaces/services/workspace-invites.service.ts
@@ -8,9 +8,11 @@ import { randomUUID } from 'node:crypto';
 import { WorkspaceInvite, WorkspaceMemberStatus } from '@budgetflow/database';
 import type { AuthenticatedUser } from '../../../common/interfaces/authenticated-request.interface';
 import { PrismaService } from '../../../core/database/prisma.service';
+import { AppLoggerService } from '../../../core/logger/app-logger.service';
 import { CreateWorkspaceInviteRequestDto } from '../dto/create-workspace-invite-request.dto';
 import { AcceptWorkspaceInviteResponseDto } from '../dto/accept-workspace-invite-response.dto';
 import { WorkspaceInviteResponseDto } from '../dto/workspace-invite-response.dto';
+import { WorkspaceInviteEmailService } from './workspace-invite-email.service';
 import { WorkspacesService } from './workspaces.service';
 
 @Injectable()
@@ -18,6 +20,8 @@ export class WorkspaceInvitesService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly workspacesService: WorkspacesService,
+    private readonly workspaceInviteEmailService: WorkspaceInviteEmailService,
+    private readonly logger: AppLoggerService,
   ) {}
 
   async createInvite(
@@ -73,6 +77,8 @@ export class WorkspaceInvitesService {
         createdByUserId: actorUserId,
       },
     });
+
+    await this.sendInviteEmail(invite, actorUserId);
 
     return this.toInviteResponse(invite);
   }
@@ -138,6 +144,8 @@ export class WorkspaceInvitesService {
         expiresAt: this.buildExpirationDate(),
       },
     });
+
+    await this.sendInviteEmail(updatedInvite, actorUserId);
 
     return this.toInviteResponse(updatedInvite);
   }
@@ -270,5 +278,40 @@ export class WorkspaceInvitesService {
     const expiration = new Date();
     expiration.setDate(expiration.getDate() + 7);
     return expiration;
+  }
+
+  private async sendInviteEmail(
+    invite: WorkspaceInvite,
+    actorUserId: string,
+  ): Promise<void> {
+    try {
+      const [workspace, actor] = await Promise.all([
+        this.prisma.workspace.findUnique({
+          where: { id: invite.workspaceId },
+          select: { name: true },
+        }),
+        this.prisma.user.findUnique({
+          where: { id: actorUserId },
+          select: { name: true },
+        }),
+      ]);
+
+      await this.workspaceInviteEmailService.sendInviteEmail({
+        recipientEmail: invite.email,
+        workspaceName: workspace?.name ?? 'BudgetFlow shared space',
+        inviteToken: invite.token,
+        inviterName: actor?.name ?? null,
+      });
+    } catch (error) {
+      this.logger.warn(
+        'Workspace invite email send attempt failed',
+        WorkspaceInvitesService.name,
+        {
+          actorUserId,
+          inviteId: invite.id,
+          message: error instanceof Error ? error.message : 'unknown',
+        },
+      );
+    }
   }
 }

--- a/apps/api/src/modules/workspaces/workspaces.module.ts
+++ b/apps/api/src/modules/workspaces/workspaces.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { WorkspaceInvitesController } from './controllers/workspace-invites.controller';
 import { WorkspaceMembersController } from './controllers/workspace-members.controller';
 import { WorkspacesController } from './controllers/workspaces.controller';
+import { WorkspaceInviteEmailService } from './services/workspace-invite-email.service';
 import { WorkspaceInvitesService } from './services/workspace-invites.service';
 import { WorkspaceMembersService } from './services/workspace-members.service';
 import { WorkspacesService } from './services/workspaces.service';
@@ -14,6 +15,7 @@ import { WorkspacesService } from './services/workspaces.service';
   ],
   providers: [
     WorkspacesService,
+    WorkspaceInviteEmailService,
     WorkspaceInvitesService,
     WorkspaceMembersService,
   ],

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,1 +1,2 @@
 BUDGETFLOW_API_URL="http://localhost:3000/api/v1"
+GOOGLE_CLIENT_ID=""

--- a/apps/web/app/(public)/auth/google/callback/route.ts
+++ b/apps/web/app/(public)/auth/google/callback/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from "next/server";
+import { signInWithGoogleCodeApi } from "@/lib/auth/api";
+import { resolvePostAuthRedirect } from "@/lib/auth/post-auth-redirect";
+import {
+  clearCookie,
+  setAccessCookie,
+  setCurrentWorkspaceCookie,
+  setRefreshCookie,
+} from "@/lib/auth/response-cookies";
+
+const GOOGLE_AUTH_STATE_COOKIE = "budgetflow_google_auth_state";
+const GOOGLE_AUTH_REDIRECT_COOKIE = "budgetflow_google_auth_redirect";
+const POST_REDIRECT_STATUS = 303;
+
+export async function GET(request: NextRequest) {
+  const code = request.nextUrl.searchParams.get("code")?.trim() || "";
+  const state = request.nextUrl.searchParams.get("state")?.trim() || "";
+  const storedState =
+    request.cookies.get(GOOGLE_AUTH_STATE_COOKIE)?.value?.trim() || "";
+  const redirectTo =
+    request.cookies.get(GOOGLE_AUTH_REDIRECT_COOKIE)?.value || "/app/dashboard";
+
+  const signInUrl = new URL("/sign-in", request.url);
+  signInUrl.searchParams.set("next", redirectTo);
+
+  if (!code || !state || !storedState || state !== storedState) {
+    signInUrl.searchParams.set("error", "social_auth_failed");
+
+    const response = NextResponse.redirect(signInUrl, POST_REDIRECT_STATUS);
+    clearCookie(response, GOOGLE_AUTH_STATE_COOKIE);
+    clearCookie(response, GOOGLE_AUTH_REDIRECT_COOKIE);
+    return response;
+  }
+
+  try {
+    const callbackUrl = new URL("/auth/google/callback", request.url);
+    const auth = await signInWithGoogleCodeApi({
+      code,
+      redirectUri: callbackUrl.toString(),
+      refreshCookieName: "budgetflow_refresh_token",
+    });
+    const { redirectUrl, selectedWorkspace } = await resolvePostAuthRedirect({
+      accessToken: auth.accessToken,
+      redirectTo,
+      requestUrl: request.url,
+      defaultToast: "signed_in",
+    });
+    const response = NextResponse.redirect(redirectUrl, POST_REDIRECT_STATUS);
+
+    setAccessCookie(response, auth.accessToken);
+
+    if (auth.refreshToken) {
+      setRefreshCookie(response, auth.refreshToken);
+    }
+
+    if (selectedWorkspace) {
+      setCurrentWorkspaceCookie(response, selectedWorkspace.id);
+    }
+
+    clearCookie(response, GOOGLE_AUTH_STATE_COOKIE);
+    clearCookie(response, GOOGLE_AUTH_REDIRECT_COOKIE);
+
+    return response;
+  } catch {
+    signInUrl.searchParams.set("error", "social_auth_failed");
+    const response = NextResponse.redirect(signInUrl, POST_REDIRECT_STATUS);
+
+    clearCookie(response, GOOGLE_AUTH_STATE_COOKIE);
+    clearCookie(response, GOOGLE_AUTH_REDIRECT_COOKIE);
+
+    return response;
+  }
+}

--- a/apps/web/app/(public)/auth/google/start/route.ts
+++ b/apps/web/app/(public)/auth/google/start/route.ts
@@ -1,0 +1,49 @@
+import { randomUUID } from "node:crypto";
+import { NextRequest, NextResponse } from "next/server";
+
+const GOOGLE_AUTH_STATE_COOKIE = "budgetflow_google_auth_state";
+const GOOGLE_AUTH_REDIRECT_COOKIE = "budgetflow_google_auth_redirect";
+
+export async function GET(request: NextRequest) {
+  const clientId = process.env.GOOGLE_CLIENT_ID;
+  const redirectTo =
+    request.nextUrl.searchParams.get("redirectTo")?.trim() || "/app/dashboard";
+
+  if (!clientId) {
+    const signInUrl = new URL("/sign-in", request.url);
+    signInUrl.searchParams.set("error", "social_auth_unavailable");
+    signInUrl.searchParams.set("next", redirectTo);
+
+    return NextResponse.redirect(signInUrl);
+  }
+
+  const callbackUrl = new URL("/auth/google/callback", request.url);
+  const state = randomUUID();
+  const googleUrl = new URL("https://accounts.google.com/o/oauth2/v2/auth");
+
+  googleUrl.searchParams.set("client_id", clientId);
+  googleUrl.searchParams.set("redirect_uri", callbackUrl.toString());
+  googleUrl.searchParams.set("response_type", "code");
+  googleUrl.searchParams.set("scope", "openid profile email");
+  googleUrl.searchParams.set("state", state);
+  googleUrl.searchParams.set("prompt", "select_account");
+
+  const response = NextResponse.redirect(googleUrl);
+
+  response.cookies.set(GOOGLE_AUTH_STATE_COOKIE, state, {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: 60 * 10,
+  });
+  response.cookies.set(GOOGLE_AUTH_REDIRECT_COOKIE, redirectTo, {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: 60 * 10,
+  });
+
+  return response;
+}

--- a/apps/web/app/(public)/auth/sign-in/route.ts
+++ b/apps/web/app/(public)/auth/sign-in/route.ts
@@ -1,36 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
-import { decodeJwtExp, signInWithApi } from "@/lib/auth/api";
+import { signInWithApi } from "@/lib/auth/api";
 import { resolvePostAuthRedirect } from "@/lib/auth/post-auth-redirect";
 import {
-  AUTH_ACCESS_COOKIE_NAME,
-  AUTH_REFRESH_COOKIE_NAME,
   CURRENT_WORKSPACE_COOKIE_NAME,
 } from "@/lib/auth/constants";
+import {
+  setAccessCookie,
+  setCurrentWorkspaceCookie,
+  setRefreshCookie,
+} from "@/lib/auth/response-cookies";
 
 const POST_REDIRECT_STATUS = 303;
-
-function setAccessCookie(response: NextResponse, accessToken: string) {
-  const exp = decodeJwtExp(accessToken);
-  const maxAge = exp ? Math.max(exp - Math.floor(Date.now() / 1000), 60) : 3600;
-
-  response.cookies.set(AUTH_ACCESS_COOKIE_NAME, accessToken, {
-    httpOnly: true,
-    sameSite: "lax",
-    secure: process.env.NODE_ENV === "production",
-    path: "/",
-    maxAge,
-  });
-}
-
-function setRefreshCookie(response: NextResponse, refreshToken: string) {
-  response.cookies.set(AUTH_REFRESH_COOKIE_NAME, refreshToken, {
-    httpOnly: true,
-    sameSite: "lax",
-    secure: process.env.NODE_ENV === "production",
-    path: "/",
-    maxAge: 60 * 60 * 24 * 30,
-  });
-}
 
 export async function POST(request: NextRequest) {
   const existingWorkspaceId =
@@ -69,13 +49,7 @@ export async function POST(request: NextRequest) {
     }
 
     if (selectedWorkspace) {
-      response.cookies.set(CURRENT_WORKSPACE_COOKIE_NAME, selectedWorkspace.id, {
-        httpOnly: true,
-        sameSite: "lax",
-        secure: process.env.NODE_ENV === "production",
-        path: "/",
-        maxAge: 60 * 60 * 24 * 30,
-      });
+      setCurrentWorkspaceCookie(response, selectedWorkspace.id);
     }
 
     return response;

--- a/apps/web/app/(public)/auth/sign-out/route.ts
+++ b/apps/web/app/(public)/auth/sign-out/route.ts
@@ -4,6 +4,7 @@ import {
   AUTH_ACCESS_COOKIE_NAME,
   AUTH_REFRESH_COOKIE_NAME,
 } from "@/lib/auth/constants";
+import { clearCookie } from "@/lib/auth/response-cookies";
 
 const POST_REDIRECT_STATUS = 303;
 
@@ -21,19 +22,7 @@ export async function POST(request: NextRequest) {
   redirectUrl.searchParams.set("toast", "signed_out");
   const response = NextResponse.redirect(redirectUrl, POST_REDIRECT_STATUS);
 
-  response.cookies.set(AUTH_ACCESS_COOKIE_NAME, "", {
-    httpOnly: true,
-    sameSite: "lax",
-    secure: process.env.NODE_ENV === "production",
-    path: "/",
-    maxAge: 0,
-  });
-  response.cookies.set(AUTH_REFRESH_COOKIE_NAME, "", {
-    httpOnly: true,
-    sameSite: "lax",
-    secure: process.env.NODE_ENV === "production",
-    path: "/",
-    maxAge: 0,
-  });
+  clearCookie(response, AUTH_ACCESS_COOKIE_NAME);
+  clearCookie(response, AUTH_REFRESH_COOKIE_NAME);
   return response;
 }

--- a/apps/web/app/(public)/auth/sign-up/route.ts
+++ b/apps/web/app/(public)/auth/sign-up/route.ts
@@ -1,36 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
-import { decodeJwtExp, signUpWithApi } from "@/lib/auth/api";
+import { signUpWithApi } from "@/lib/auth/api";
 import { resolvePostAuthRedirect } from "@/lib/auth/post-auth-redirect";
 import {
-  AUTH_ACCESS_COOKIE_NAME,
-  AUTH_REFRESH_COOKIE_NAME,
-  CURRENT_WORKSPACE_COOKIE_NAME,
-} from "@/lib/auth/constants";
+  setAccessCookie,
+  setCurrentWorkspaceCookie,
+  setRefreshCookie,
+} from "@/lib/auth/response-cookies";
 
 const POST_REDIRECT_STATUS = 303;
-
-function setAccessCookie(response: NextResponse, accessToken: string) {
-  const exp = decodeJwtExp(accessToken);
-  const maxAge = exp ? Math.max(exp - Math.floor(Date.now() / 1000), 60) : 3600;
-
-  response.cookies.set(AUTH_ACCESS_COOKIE_NAME, accessToken, {
-    httpOnly: true,
-    sameSite: "lax",
-    secure: process.env.NODE_ENV === "production",
-    path: "/",
-    maxAge,
-  });
-}
-
-function setRefreshCookie(response: NextResponse, refreshToken: string) {
-  response.cookies.set(AUTH_REFRESH_COOKIE_NAME, refreshToken, {
-    httpOnly: true,
-    sameSite: "lax",
-    secure: process.env.NODE_ENV === "production",
-    path: "/",
-    maxAge: 60 * 60 * 24 * 30,
-  });
-}
 
 export async function POST(request: NextRequest) {
   const formData = await request.formData();
@@ -72,13 +49,7 @@ export async function POST(request: NextRequest) {
     }
 
     if (selectedWorkspace) {
-      response.cookies.set(CURRENT_WORKSPACE_COOKIE_NAME, selectedWorkspace.id, {
-        httpOnly: true,
-        sameSite: "lax",
-        secure: process.env.NODE_ENV === "production",
-        path: "/",
-        maxAge: 60 * 60 * 24 * 30,
-      });
+      setCurrentWorkspaceCookie(response, selectedWorkspace.id);
     }
 
     return response;

--- a/apps/web/app/(public)/sign-in/page.tsx
+++ b/apps/web/app/(public)/sign-in/page.tsx
@@ -8,6 +8,7 @@ export default async function SignInPage({
 }) {
   const params = await searchParams;
   const next = params.next ?? "/app/dashboard";
+  const isGoogleEnabled = Boolean(process.env.GOOGLE_CLIENT_ID);
 
   return (
     <main className="min-h-screen bg-slate-950 text-white">
@@ -88,6 +89,18 @@ export default async function SignInPage({
               Sign in
             </AppButton>
           </form>
+
+          {isGoogleEnabled ? (
+            <div className="mt-4 border-t border-white/10 pt-4">
+              <AppButtonLink
+                href={`/auth/google/start?redirectTo=${encodeURIComponent(next)}`}
+                tone="secondary"
+                className="w-full border-white/20 bg-white/8 text-white shadow-none hover:border-white/35 hover:bg-white/14 hover:text-white"
+              >
+                Continue with Google
+              </AppButtonLink>
+            </div>
+          ) : null}
 
           <p className="mt-6 text-sm text-slate-400">
             Need a new account?{" "}

--- a/apps/web/app/(public)/sign-up/page.tsx
+++ b/apps/web/app/(public)/sign-up/page.tsx
@@ -8,6 +8,7 @@ export default async function SignUpPage({
 }) {
   const params = await searchParams;
   const next = params.next ?? "/app/dashboard";
+  const isGoogleEnabled = Boolean(process.env.GOOGLE_CLIENT_ID);
 
   return (
     <main className="min-h-screen bg-[#f4f6f2] text-slate-950">
@@ -86,6 +87,17 @@ export default async function SignUpPage({
               </AppButtonLink>
             </div>
           </form>
+
+          {isGoogleEnabled ? (
+            <div className="mt-6 border-t border-slate-900/8 pt-6">
+              <AppButtonLink
+                href={`/auth/google/start?redirectTo=${encodeURIComponent(next)}`}
+                className="px-6 py-3"
+              >
+                Continue with Google
+              </AppButtonLink>
+            </div>
+          ) : null}
         </div>
       </div>
     </main>

--- a/apps/web/components/feedback/url-toast-bridge.tsx
+++ b/apps/web/components/feedback/url-toast-bridge.tsx
@@ -21,6 +21,14 @@ const TOAST_MESSAGES: Record<string, { type: "success" | "error"; text: string }
     type: "success",
     text: "Signed in.",
   },
+  social_auth_failed: {
+    type: "error",
+    text: "Google sign-in failed.",
+  },
+  social_auth_unavailable: {
+    type: "error",
+    text: "Google sign-in is not configured yet.",
+  },
   signed_out: {
     type: "success",
     text: "Signed out.",

--- a/apps/web/lib/auth/api.ts
+++ b/apps/web/lib/auth/api.ts
@@ -131,6 +131,26 @@ export async function signUpWithApi(input: {
   return parseAuthResponse(response, input.refreshCookieName);
 }
 
+export async function signInWithGoogleCodeApi(input: {
+  code: string;
+  redirectUri: string;
+  refreshCookieName: string;
+}) {
+  const response = await fetch(`${getApiBaseUrl()}/auth/google`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    cache: "no-store",
+    body: JSON.stringify({
+      code: input.code,
+      redirectUri: input.redirectUri,
+    }),
+  });
+
+  return parseAuthResponse(response, input.refreshCookieName);
+}
+
 export async function refreshWithApi(input: {
   refreshToken: string;
   refreshCookieName: string;

--- a/apps/web/lib/auth/response-cookies.ts
+++ b/apps/web/lib/auth/response-cookies.ts
@@ -1,0 +1,55 @@
+import "server-only";
+
+import type { NextResponse } from "next/server";
+import { decodeJwtExp } from "@/lib/auth/api";
+import {
+  AUTH_ACCESS_COOKIE_NAME,
+  AUTH_REFRESH_COOKIE_NAME,
+  CURRENT_WORKSPACE_COOKIE_NAME,
+} from "@/lib/auth/constants";
+
+export function setAccessCookie(response: NextResponse, accessToken: string) {
+  const exp = decodeJwtExp(accessToken);
+  const maxAge = exp ? Math.max(exp - Math.floor(Date.now() / 1000), 60) : 3600;
+
+  response.cookies.set(AUTH_ACCESS_COOKIE_NAME, accessToken, {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge,
+  });
+}
+
+export function setRefreshCookie(response: NextResponse, refreshToken: string) {
+  response.cookies.set(AUTH_REFRESH_COOKIE_NAME, refreshToken, {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: 60 * 60 * 24 * 30,
+  });
+}
+
+export function setCurrentWorkspaceCookie(
+  response: NextResponse,
+  workspaceId: string,
+) {
+  response.cookies.set(CURRENT_WORKSPACE_COOKIE_NAME, workspaceId, {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: 60 * 60 * 24 * 30,
+  });
+}
+
+export function clearCookie(response: NextResponse, name: string) {
+  response.cookies.set(name, "", {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: 0,
+  });
+}

--- a/docs/DEPLOY_VERCEL_RAILWAY.md
+++ b/docs/DEPLOY_VERCEL_RAILWAY.md
@@ -32,6 +32,9 @@ Prepare these production values first:
 - production web origin
 - production API origin
 - cookie domain
+- invite email sender address
+- Resend API key
+- Google OAuth client ID and client secret
 - recurring scheduler decision
 
 Recommended domain pattern:
@@ -79,6 +82,11 @@ Set these required API environment variables:
 - `AUTH_REFRESH_COOKIE_SECURE=true`
 - `TRUST_PROXY=true`
 - `PASSWORD_HASH_SALT_ROUNDS=10`
+- `APP_WEB_URL=https://app.example.com`
+- `RESEND_API_KEY=<resend api key>`
+- `INVITE_EMAIL_FROM=BudgetFlow <invites@example.com>`
+- `GOOGLE_CLIENT_ID=<google oauth client id>`
+- `GOOGLE_CLIENT_SECRET=<google oauth client secret>`
 
 Recurring execution variables:
 
@@ -113,6 +121,7 @@ Use these project settings:
 Set this required web environment variable:
 
 - `BUDGETFLOW_API_URL=https://api.example.com/api/v1`
+- `GOOGLE_CLIENT_ID=<google oauth client id>`
 
 Notes:
 
@@ -131,6 +140,7 @@ Then confirm:
 - API CORS allows only `https://app.example.com`
 - cookie domain is `.example.com`
 - cookie secure is enabled
+- Google OAuth redirect URI includes `https://app.example.com/auth/google/callback`
 
 ## 6. Pre-Release Validation
 

--- a/packages/database/prisma/migrations/20260402173500_add_auth_identities/migration.sql
+++ b/packages/database/prisma/migrations/20260402173500_add_auth_identities/migration.sql
@@ -1,0 +1,21 @@
+CREATE TYPE "AuthIdentityProvider" AS ENUM ('GOOGLE', 'KAKAO', 'APPLE');
+
+CREATE TABLE "auth_identities" (
+    "id" UUID NOT NULL,
+    "user_id" UUID NOT NULL,
+    "provider" "AuthIdentityProvider" NOT NULL,
+    "provider_subject" TEXT NOT NULL,
+    "email" TEXT,
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(6) NOT NULL,
+
+    CONSTRAINT "auth_identities_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "auth_identities_provider_provider_subject_key" ON "auth_identities"("provider", "provider_subject");
+CREATE UNIQUE INDEX "auth_identities_user_id_provider_key" ON "auth_identities"("user_id", "provider");
+CREATE INDEX "auth_identities_user_id_idx" ON "auth_identities"("user_id");
+
+ALTER TABLE "auth_identities"
+ADD CONSTRAINT "auth_identities_user_id_fkey"
+FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -27,6 +27,12 @@ enum WorkspaceMemberStatus {
   LEFT
 }
 
+enum AuthIdentityProvider {
+  GOOGLE
+  KAKAO
+  APPLE
+}
+
 enum CategoryType {
   INCOME
   EXPENSE
@@ -88,6 +94,7 @@ model User {
   timezone                String                   @default("Asia/Seoul")
   createdAt               DateTime                 @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt               DateTime                 @updatedAt @map("updated_at") @db.Timestamptz(6)
+  authIdentities          AuthIdentity[]
   authSessions            AuthSession[]
   ownedWorkspaces         Workspace[]              @relation("WorkspaceOwner")
   workspaceMemberships    WorkspaceMember[]
@@ -107,6 +114,22 @@ model User {
   notificationReads       NotificationRead[]
 
   @@map("users")
+}
+
+model AuthIdentity {
+  id              String               @id @default(uuid()) @db.Uuid
+  userId          String               @map("user_id") @db.Uuid
+  provider        AuthIdentityProvider
+  providerSubject String               @map("provider_subject")
+  email           String?
+  createdAt       DateTime             @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt       DateTime             @updatedAt @map("updated_at") @db.Timestamptz(6)
+  user            User                 @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([provider, providerSubject])
+  @@unique([userId, provider])
+  @@index([userId])
+  @@map("auth_identities")
 }
 
 model AuthSession {


### PR DESCRIPTION
## Summary
- send shared workspace invite emails through Resend when delivery is configured
- add Google sign-in and account linking on top of the existing auth flow
- document the extra production env and OAuth callback settings

## Verification
- pnpm prisma:generate
- pnpm --filter @budgetflow/api test -- auth.service.spec.ts workspace-invites.service.spec.ts workspace-members.service.spec.ts workspace-members.controller.spec.ts --runInBand
- pnpm --filter @budgetflow/api build
- pnpm --filter @budgetflow/web lint
- pnpm --filter @budgetflow/web build
- pnpm test:web:e2e

Refs #68
